### PR TITLE
Modified eos-s3-hal remote path

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -21,8 +21,8 @@ manifest:
   remotes:
     - name: upstream
       url-base: https://github.com/zephyrproject-rtos
-    - name: antmicro
-      url-base: https://github.com/antmicro
+    - name: QuickLogic-Corp
+      url-base: https://github.com/QuickLogic-Corp
 
   #
   # Please add items below based on alphabetical order
@@ -70,7 +70,7 @@ manifest:
       revision: 45e630d6152824f807d3f919958605c4626cbdff
       path: modules/hal/libmetal
     - name: hal_quicklogic
-      remote: antmicro
+      remote: QuickLogic-Corp
       repo-path: eos-s3-hal
       revision: 3660cf0de092035c23df0392defb7f9dd0da191c
       path: modules/hal/quicklogic


### PR DESCRIPTION
This change is required to get the s3 hal files into zephyr project automatically from eos-s3-hal repository 