### PR TITLE
spi flash sample offset fix

### DIFF
--- a/boards/arm/quick_feather/quick_feather.dts
+++ b/boards/arm/quick_feather/quick_feather.dts
@@ -151,7 +151,7 @@
 		};
 		slot3_partition: partition@80000 {
 			label = "image-3";
-			reg = <0x00080000 0x00020000>;
+			reg = <0x00080000 0x00080000>;
 		};
 		storage_partition: partition@100000 {
 			label = "storage";

--- a/samples/drivers/spi_flash/src/main.c
+++ b/samples/drivers/spi_flash/src/main.c
@@ -21,7 +21,11 @@
 #error Unsupported flash driver
 #endif
 
+#ifdef CONFIG_BOARD_QUICK_FEATHER
 #define FLASH_TEST_REGION_OFFSET 0x100000
+#else
+#define FLASH_TEST_REGION_OFFSET 0xff000
+#endif
 #define FLASH_SECTOR_SIZE        4096
 
 void main(void)


### PR DESCRIPTION
Kept the original offset as it is. For quick feather board offset is
changed to 0x100000
Corrected the image-3 size in quick feather dts file